### PR TITLE
Allow accessing methods only defined in the target

### DIFF
--- a/src/ptree/node/node.js
+++ b/src/ptree/node/node.js
@@ -18,7 +18,8 @@ export default class Node {
         this[prop]
     }
 
-    if (!target.hasOwnProperty(prop)) {
+    // prop is not defined in target neither as a property nor as a method
+    if (!target[prop]) {
       return undefined
     }
 

--- a/test/ptree/node.spec.js
+++ b/test/ptree/node.spec.js
@@ -1,0 +1,16 @@
+import sinon from "sinon"
+import { expect } from "chai"
+
+import Tree from "../../src/ptree"
+
+describe("Node", () => {
+  it("allows accessing methods only defined on the proxied target value", () => {
+    const tree = new Tree({
+      users: [
+        { name: "Diego" }
+      ]
+    })
+
+    expect(tree.root.users.hasOwnProperty(0)).to.eq(true)
+  })
+})


### PR DESCRIPTION
This fixes #2.

Because `get` trap in the Proxy handler was using `hasOwnProperty` to check whether `target` defines `prop`, methods calls were always returning false since they are not considered properties.