### PR TITLE
Implement timetravel Store enhancer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,12 @@
 import Tree, { Path, create } from "./ptree"
 import connect from "./react/connect"
+import timetravel from "./timetravel"
 
-export { Tree }
-export { connect }
+export {
+  timetravel,
+  connect,
+  Tree,
+}
 
 export default class Store {
   constructor(initialState = {}) {

--- a/src/timetravel/index.js
+++ b/src/timetravel/index.js
@@ -1,0 +1,10 @@
+import Timeline from "./timeline"
+
+const timetravel = (Store) => class extends Store {
+  constructor(initialState) {
+    super(initialState)
+    this.timeline = new Timeline(this)
+  }
+}
+
+export default timetravel

--- a/src/timetravel/timeline.js
+++ b/src/timetravel/timeline.js
@@ -1,0 +1,85 @@
+import { Path, create } from "../ptree"
+
+export default class Timeline {
+  constructor(store) {
+    this.store = store
+    this.cursor = 0
+    this.history = []
+    this.history.push(this.store.state)
+  }
+
+  on() {
+    this.unsubscribe = this.store.subscribe(state => {
+      this.history.push(state)
+      this.travel.present()
+    })
+  }
+
+  off() {
+    this.unsubscribe && this.unsubscribe()
+    this.unsubscribe = undefined
+  }
+
+  get isOn() {
+    return this.unsubscribe !== undefined
+  }
+
+  get isOff() {
+    return !this.isOn
+  }
+
+  go() {
+    if (this.cursor < 0) {
+      // pin cursor at the first history entry
+      this.cursor = 0
+    }
+
+    if (this.cursor >= this.history.length) {
+      // pin cursor at the last history entry
+      this.cursor = this.history.length - 1
+    }
+
+    const state = this.history[this.cursor]
+
+    this.off()
+    this.store.tree.root = create(this.store.tree, Path.root, state, state.$children)
+    this.store.tree.pubsub.publish(Path.root, state)
+    this.on()
+  }
+
+  get travel() {
+    const timeline = this
+    const noopAPI = {
+      step() {},
+      to() {},
+      origin() {},
+      present() {},
+    }
+
+    return !this.unsubscribe ? noopAPI : {
+      step(n = 0) {
+        const prevCursor = this.cursor
+        timeline.cursor += n
+
+        if (timeline.cursor !== prevCursor) {
+          timeline.go()
+        }
+      },
+
+      to(cursor = 0) {
+        timeline.cursor = cursor
+        timeline.go()
+      },
+
+      origin() {
+        timeline.cursor = 0
+        timeline.go()
+      },
+
+      present() {
+        timeline.cursor = timeline.history.length - 1
+        timeline.go()
+      },
+    }
+  }
+}

--- a/test/timetravel/timetravel.spec.js
+++ b/test/timetravel/timetravel.spec.js
@@ -1,0 +1,218 @@
+import sinon from "sinon"
+import { expect } from "chai"
+
+import Store, { timetravel } from "../../src"
+
+describe("#timeline", () => {
+  const StoreWithTimetravel = timetravel(Store)
+
+  describe("#move", () => {
+    it("moves back in time", () => {
+      const store = new StoreWithTimetravel({
+        user: {
+          name: "Diego",
+          age: 32,
+        }
+      })
+
+      store.timeline.on()
+
+      store.state.user.name = "Bianca"
+      store.state.user.age = 24
+
+      expect(store.state.user).to.deep.eq({
+        name: "Bianca",
+        age: 24,
+      })
+
+      store.timeline.travel.step(-1)
+
+      expect(store.state.user).to.deep.eq({
+        name: "Bianca",
+        age: 32,
+      })
+
+      store.timeline.travel.step(-1)
+
+      expect(store.state.user).to.deep.eq({
+        name: "Diego",
+        age: 32,
+      })
+
+      store.timeline.travel.step(-1)
+
+      expect(store.state.user).to.deep.eq({
+        name: "Diego",
+        age: 32,
+      })
+    })
+
+    it("moves forward in time", () => {
+      const store = new StoreWithTimetravel({
+        user: {
+          name: "Diego",
+          age: 32,
+        }
+      })
+
+      store.timeline.on()
+
+      store.state.user.name = "Bianca"
+      store.state.user.age = 24
+
+      store.timeline.travel.step(-2)
+      store.timeline.travel.step(1)
+
+      expect(store.state.user).to.deep.eq({
+        name: "Bianca",
+        age: 32,
+      })
+
+      store.timeline.travel.step(1)
+
+      expect(store.state.user).to.deep.eq({
+        name: "Bianca",
+        age: 24,
+      })
+
+      store.timeline.travel.step(1)
+
+      expect(store.state.user).to.deep.eq({
+        name: "Bianca",
+        age: 24,
+      })
+    })
+  })
+
+  describe("#travelTo", () => {
+    it("moves to an especific point in time", () => {
+      const store = new StoreWithTimetravel({
+        user: {
+          name: "Diego",
+          age: 32,
+        }
+      })
+
+      store.timeline.on()
+
+      store.state.user.name = "Bianca"
+      store.state.user.age = 24
+
+      store.timeline.travel.to(1)
+
+      expect(store.state.user).to.deep.eq({
+        name: "Bianca",
+        age: 32,
+      })
+    })
+
+    it("does not move time out of its boundaries", () => {
+      const store = new StoreWithTimetravel({
+        user: {
+          name: "Diego",
+          age: 32,
+        }
+      })
+
+      store.timeline.on()
+
+      store.state.user.name = "Bianca"
+      store.state.user.age = 24
+
+      store.timeline.travel.to(3)
+
+      expect(store.timeline.cursor).to.eq(2)
+
+      store.timeline.travel.to(-1)
+
+      expect(store.timeline.cursor).to.eq(0)
+    })
+  })
+
+  describe("#origin", () => {
+    it("moves to the beginning of time", () => {
+      const store = new StoreWithTimetravel({
+        user: {
+          name: "Diego",
+          age: 32,
+        }
+      })
+
+      store.timeline.on()
+
+      store.state.user.name = "Bianca"
+      store.state.user.age = 24
+
+      store.timeline.travel.origin()
+
+      expect(store.state.user).to.deep.eq({
+        name: "Diego",
+        age: 32,
+      })
+    })
+  })
+
+  describe("#present", () => {
+    it("moves time to the present state", () => {
+      const store = new StoreWithTimetravel({
+        user: {
+          name: "Diego",
+          age: 32,
+        }
+      })
+
+      store.timeline.on()
+
+      store.state.user.name = "Bianca"
+      store.state.user.age = 24
+
+      store.timeline.travel.step(-2)
+      store.timeline.travel.present()
+
+      expect(store.state.user).to.deep.eq({
+        name: "Bianca",
+        age: 24,
+      })
+    })
+  })
+
+  describe("#on", () => {
+    it("turns timetravel on", () => {
+      const store = new StoreWithTimetravel({
+        user: {
+          name: "Diego",
+          age: 32,
+        }
+      })
+
+      expect(store.timeline.isOn).to.eq(false)
+      expect(store.timeline.isOff).to.eq(true)
+
+      store.timeline.on()
+
+      expect(store.timeline.isOn).to.eq(true)
+      expect(store.timeline.isOff).to.eq(false)
+    })
+  })
+
+  describe("#off", () => {
+    it("turns timetravel off", () => {
+      const store = new StoreWithTimetravel({
+        user: {
+          name: "Diego",
+          age: 32,
+        }
+      })
+
+      store.timeline.on()
+
+      expect(store.timeline.isOn).to.eq(true)
+      expect(store.timeline.isOff).to.eq(false)
+
+      store.timeline.off()
+
+      expect(store.timeline.isOn).to.eq(false)
+      expect(store.timeline.isOff).to.eq(true)
+    })
+  })
+})


### PR DESCRIPTION
Provides time traveling functionality to an arbor `Store`, allowing one to move back and forth in the time history.

This could be particularly useful in a tool (browser plugin?) as a way to record user interactions and provide a playback feature for developers to reproduce certain bug scenarios.

![2017-12-14 20 51 16](https://user-images.githubusercontent.com/508128/34018352-9d031a56-e110-11e7-9e3f-9f30a3c2e8ad.gif)

Resolves #4 