### PR TITLE
Allow traveling through time when timeline is off

### DIFF
--- a/src/timetravel/timeline.js
+++ b/src/timetravel/timeline.js
@@ -49,14 +49,7 @@ export default class Timeline {
 
   get travel() {
     const timeline = this
-    const noopAPI = {
-      step() {},
-      to() {},
-      origin() {},
-      present() {},
-    }
-
-    return !this.unsubscribe ? noopAPI : {
+    return {
       step(n = 0) {
         const prevCursor = this.cursor
         timeline.cursor += n

--- a/test/timetravel/timetravel.spec.js
+++ b/test/timetravel/timetravel.spec.js
@@ -214,5 +214,24 @@ describe("#timeline", () => {
       expect(store.timeline.isOn).to.eq(false)
       expect(store.timeline.isOff).to.eq(true)
     })
+
+    it("one can still travel through time when timetravel is off", () => {
+      const store = new StoreWithTimetravel({
+        user: {
+          name: "Diego",
+          age: 32,
+        }
+      })
+
+      store.timeline.on()
+
+      store.state.user.name = "Bianca"
+
+      store.timeline.off()
+
+      store.timeline.travel.origin()
+
+      expect(store.state.user.name).to.eq("Diego")
+    })
   })
 })


### PR DESCRIPTION
Time traveling should be allowed even when timeline is off. Turning off the timeline only means it will stop recording state mutations for the period of time it is off. Perhaps this API needs to be renamed?