### PR TITLE
Make react component state property a proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chai": "^3.5.0",
     "chai-enzyme": "^1.0.0-beta.0",
     "enzyme": "^3.2.0",
+    "enzyme-adapter-react-16": "^1.1.0",
     "flow-bin": "^0.42.0",
     "flow-watch": "^1.1.1",
     "growl": "^1.9.2",

--- a/src/react/connect.js
+++ b/src/react/connect.js
@@ -5,7 +5,7 @@ export default function connect(store) {
 
       componentDidMount() {
         super.componentDidMount && super.componentDidMount()
-        this.unsubscribe = store.subscribe("/", (state) => this.setState(state))
+        this.unsubscribe = store.subscribe("/", (state) => this.setState(state, () => { this.state = state }))
       }
 
       componentWillUnmount() {

--- a/test/react/connect.spec.js
+++ b/test/react/connect.spec.js
@@ -1,0 +1,49 @@
+import React from "react"
+import sinon from "sinon"
+import { expect } from "chai"
+import { shallow } from "enzyme"
+
+import Store from "../../src"
+import connect from "../../src/react/connect"
+
+describe("connect", () => {
+  class Counter extends React.Component {
+    render() {
+      return (
+        <span>{this.state.count}</span>
+      )
+    }
+  }
+
+  it("subscribes a React component to store mutations", () => {
+    const store = new Store({ count: 0 })
+    const CounterApp = connect(store)(Counter)
+
+    const wrapper = shallow(<CounterApp />)
+
+    store.state.count++
+
+    wrapper.update()
+
+    expect(wrapper.find("span")).to.have.text("1")
+
+    store.state.count++
+
+    wrapper.update()
+
+    expect(wrapper.find("span")).to.have.text("2")
+  })
+
+  it("unsubscribes a React component from store mutations", () => {
+    const store = new Store({ count: 0 })
+    const CounterApp = connect(store)(Counter)
+
+    const wrapper = shallow(<CounterApp />)
+
+    expect(store.tree.pubsub.subscriptions["/"]).to.not.be.empty
+
+    wrapper.instance().componentWillUnmount()
+
+    expect(store.tree.pubsub.subscriptions["/"]).to.be.empty
+  })
+})

--- a/test/spec.helper.js
+++ b/test/spec.helper.js
@@ -1,6 +1,10 @@
+const Enzyme = require("enzyme")
 const chai = require("chai")
 const sinonChai = require("sinon-chai")
 const chaiEnzyme = require("chai-enzyme")
+const Adapter = require("enzyme-adapter-react-16")
+
+Enzyme.configure({ adapter: new Adapter() });
 
 chai.use(chaiEnzyme())
 chai.use(sinonChai)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,6 +1654,25 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+enzyme-adapter-react-16@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.0.tgz#86c5db7c10f0be6ec25d54ca41b59f2abb397cf4"
+  dependencies:
+    enzyme-adapter-utils "^1.1.0"
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    object.values "^1.0.4"
+    prop-types "^15.5.10"
+    react-test-renderer "^16.0.0-0"
+
+enzyme-adapter-utils@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.2.0.tgz#7f4471ee0a70b91169ec8860d2bf0a6b551664b2"
+  dependencies:
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    prop-types "^15.5.10"
+
 enzyme@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.2.0.tgz#998bdcda0fc71b8764a0017f7cc692c943f54a7a"
@@ -3582,7 +3601,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -3722,6 +3741,14 @@ react-dom@^16.2.0:
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-test-renderer@^16.0.0-0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
+  dependencies:
+    fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 


### PR DESCRIPTION
This allows mutations to happen on state fields even when they are not proxies themselves, e.g.:

```js
this.state.name = "Diego"
// This now triggers a mutation at path /name
```