### PR TITLE
Support atomic node transformations

### DIFF
--- a/src/ptree/mutations.js
+++ b/src/ptree/mutations.js
@@ -51,6 +51,12 @@ const shift = () => (node) => {
   node.$value.shift()
 }
 
+const transaction = (fn) => (node) => {
+  node.$tree.transactionNode = node
+  fn(node)
+  node.$tree.transactionNode = null
+}
+
 const unshift = (items) => (node) => {
   node.$children = []
   node.$value.unshift(...items)
@@ -63,5 +69,6 @@ export default {
   shift,
   sort,
   splice,
+  transaction,
   unshift,
 }

--- a/src/ptree/mutator.js
+++ b/src/ptree/mutator.js
@@ -9,7 +9,7 @@ class Mutator {
       mutation(node, childProp)
 
     } else {
-      const child = node.$children[childProp]
+      const child = node[childProp]
       // Make sure only nodes affected by the mutation are refreshed. This allows
       // libs such as React to make reference comparissons between objects in
       // order to determine whether a mutation has happened and thus allowing the

--- a/src/ptree/node/array.js
+++ b/src/ptree/node/array.js
@@ -2,9 +2,9 @@ import Node from "./node"
 import mutations from "../mutations"
 
 export default class NodeArray extends Node {
-  constructor($tree, $path, value, $children = {}) {
-    super($tree, $path, value, $children)
-    return new Proxy(value, this)
+  constructor($tree, $path, $value, $children = {}) {
+    super($tree, $path, $value, $children)
+    return new Proxy($value, this)
   }
 
   splice = (path) => (start, removeCount, ...newItems) => {

--- a/src/ptree/node/index.js
+++ b/src/ptree/node/index.js
@@ -1,6 +1,5 @@
 import Node from "./node"
-import NodeArray from "./array"
-import NodeObject from "./object"
 
-export { NodeObject, NodeArray }
+export NodeObject from "./object"
+export NodeArray from "./array"
 export default Node

--- a/src/ptree/node/node.js
+++ b/src/ptree/node/node.js
@@ -8,10 +8,10 @@ const isLeafNode = (value) =>
   value.constructor !== Array
 
 export default class Node {
-  constructor($tree, $path, value, $children = {}) {
+  constructor($tree, $path, $value, $children = {}) {
     this.$tree = $tree
     this.$path = $path
-    this.$value = value
+    this.$value = $value
     this.$children = $children
   }
 
@@ -42,6 +42,14 @@ export default class Node {
     }
 
     return true
+  }
+
+  transaction = (path) => (fn) => {
+    if (this.$tree.transactionNode) {
+      throw "Transaction already in progress"
+    } else {
+      this.$tree.mutate(path, mutations.transaction(fn))
+    }
   }
 
   createChild(prop, value) {

--- a/src/ptree/node/object.js
+++ b/src/ptree/node/object.js
@@ -1,9 +1,9 @@
 import Node from "./node"
 
 export default class NodeObject extends Node {
-  constructor($tree, $path, value, $children = {}) {
-    super($tree, $path, value, $children)
-    return new Proxy(value, this)
+  constructor($tree, $path, $value, $children = {}) {
+    super($tree, $path, $value, $children)
+    return new Proxy($value, this)
   }
 
   copy = () => this.$tree.create(

--- a/test/ptree/node/node.spec.js
+++ b/test/ptree/node/node.spec.js
@@ -1,7 +1,7 @@
 import sinon from "sinon"
 import { expect } from "chai"
 
-import Tree from "../../../src/ptree"
+import Tree, { Path } from "../../../src/ptree"
 
 describe("Node", () => {
   describe("#get", () => {
@@ -59,6 +59,196 @@ describe("Node", () => {
       tree.root.user.$value = { child: "fake child" }
 
       expect(tree.root.user.$value).to.deep.eq({ child: "fake child" })
+    })
+  })
+
+  describe("#transaction", () => {
+    it("transactions node object atomically", () => {
+      const subscriber = sinon.spy()
+      const tree = new Tree({
+        user: { name: "Diego" }
+      })
+
+      tree.subscribe(Path.root, subscriber)
+
+      const user = tree.root.user
+
+      user.transaction((node) => {
+        node.name = "Borges"
+        node.age = 32
+
+        expect(node).to.not.eq(user)
+        expect(node).to.deep.eq({
+          name: "Borges",
+          age: 32,
+        })
+      })
+
+      expect(user).to.deep.eq({ name: "Diego" })
+      expect(tree.root.user).to.deep.eq({
+        name: "Borges",
+        age: 32,
+      })
+
+      expect(subscriber).to.have.been.calledOnce
+      expect(subscriber).to.have.been.calledWith({
+        user: {
+          name: "Borges",
+          age: 32,
+        }
+      })
+    })
+
+    it("transactions node array atomically", () => {
+      const subscriber = sinon.spy()
+      const tree = new Tree({
+        users: [{ name: "Diego" }],
+      })
+
+      tree.subscribe(Path.root, subscriber)
+
+      const users = tree.root.users
+
+      users.transaction((node) => {
+        node.splice(0, 1)
+        node.push({ name: "John" })
+
+        expect(node).to.not.eq(users)
+        expect(node).to.deep.eq([
+          { name: "John" },
+        ])
+      })
+
+      expect(users).to.deep.eq([{ name: "Diego" }])
+      expect(tree.root.users).to.deep.eq([
+        { name: "John" },
+      ])
+
+      expect(subscriber).to.have.been.calledOnce
+      expect(subscriber).to.have.been.calledWith({
+        users: [
+          { name: "John" },
+        ]
+      })
+    })
+
+    it("throws an error upon nested transactions", () => {
+      const subscriber = sinon.spy()
+      const tree = new Tree({
+        users: [{ name: "Diego" }],
+      })
+
+      tree.subscribe(Path.root, subscriber)
+
+      const users = tree.root.users
+
+      users.transaction((node) => {
+        expect(() => node[0].transaction()).to.throw()
+      })
+    })
+
+    it("throws an error when mutating node outside the transaction subtree", () => {
+      const subscriber = sinon.spy()
+      const tree = new Tree({
+        users: [{ name: "Diego" }],
+      })
+
+      tree.subscribe(Path.root, subscriber)
+
+      const users = tree.root.users
+
+      users[0].transaction((user) => {
+        expect(() => users.push({ name: "cannot mutate node outside transaction tree" })).to.throw()
+      })
+    })
+
+    context("structural sharing", () => {
+      it("caches children copies for futher accesses", () => {
+        const tree = new Tree({
+          users: [{ name: "Diego" }]
+        })
+
+        const users = tree.root.users
+
+        users.transaction((node) => {
+          const firstAccess = node[0]
+          const secondAccess = node[0]
+
+          expect(firstAccess).to.eq(secondAccess)
+        })
+      })
+
+      it("state tree is only updated after transaction is finished", () => {
+        const tree = new Tree({
+          users: [{ name: "Diego" }]
+        })
+
+        const users = tree.root.users
+
+        users.transaction((node) => {
+          // one may trigger mutations on either `users` or `node` variables,
+          // both will generate the same mutation path so the new state tree
+          // can be created.
+          users[0].name = "Borges"
+          node[0].age = 32
+
+          expect(node[0]).to.deep.eq({
+            name: "Borges",
+            age: 32,
+          })
+
+          expect(users[0]).to.deep.eq({ name: "Diego" })
+          expect(tree.root.users[0]).to.deep.eq({ name: "Diego" })
+        })
+
+        expect(tree.root.users[0].name).to.eq("Borges")
+      })
+
+      it("mutations on child object is applied to a new copy", () => {
+        const tree = new Tree({
+          users: [{ name: "Diego" }]
+        })
+
+        const users = tree.root.users
+        const user = tree.root.users[0]
+
+        users.transaction((node) => {
+          expect(node).to.not.eq(users)
+          node[0].name = "Borges"
+        })
+
+        expect(users).to.deep.eq([{ name: "Diego" }])
+        expect(tree.root.users).to.deep.eq([
+          { name: "Borges" },
+        ])
+      })
+
+      it("mutations on child array is applied to a new copy", () => {
+        const tree = new Tree({
+          users: [{ name: "Diego", posts: [{ title: "Nice" }]}]
+        })
+
+        const users = tree.root.users
+        const user = tree.root.users[0]
+        const posts = user.posts
+        const post = posts[0]
+
+        users.transaction((node) => {
+          expect(node).to.not.eq(users)
+          node[0].posts[0].title = "Sweet"
+          expect(node[0]).to.not.eq(user)
+          expect(node[0].posts).to.not.eq(posts)
+          expect(node[0].posts[0]).to.not.eq(post)
+        })
+
+        expect(users).to.deep.eq([
+          { name: "Diego", posts: [{ title: "Nice" }]}
+        ])
+
+        expect(tree.root.users).to.deep.eq([
+          { name: "Diego", posts: [{ title: "Sweet" }]}
+        ])
+      })
     })
   })
 })


### PR DESCRIPTION
Provides a way to apply multiple mutations to a given node atomically. This means that subscribers will receive a single notification about the change applied to the corresponding node.

```js
const store = new Store({
  users: [{ name: "Borges" }],
})

const originalUsers = store.state.users

store.subscribe(console.log)
// => { users: [{ name: "Diego", age: 32 }] }

store.state.users[0].transaction(user => {
  // We are free to mutate the "user" instance however we want and subscribers will only
  // receive a single notification with the final state after the transaction is finished.
  user.name ="Diego"
  user.age = 32
})

// The original state tree is preserved, every mutation in Arbor causes a new state tree to
// be generated, allowing for state time traveling features.
console.log(originalUsers)
// => [{ name: "Borges" }]
```

Resolves #36 