### PR TITLE
Remove unused Path#iterator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,10 @@
 {
-    "presets": ["env"],
+  "presets": ["env"],
   "plugins": [
     "transform-class-properties",
     "transform-export-extensions",
     "transform-decorators-legacy",
     "transform-object-rest-spread",
-    "transform-es2015-computed-properties",
-    ["transform-runtime", { "polyfill": false }]
+    "transform-es2015-computed-properties"
   ]
 }

--- a/src/path/path.js
+++ b/src/path/path.js
@@ -55,10 +55,4 @@ export default class Path {
   get depth() {
     return this.nodes.length
   }
-
-  *[Symbol.iterator]() {
-    for (const node of this.nodes) {
-      yield node
-    }
-  }
 }

--- a/test/path/path.spec.js
+++ b/test/path/path.spec.js
@@ -105,25 +105,6 @@ describe("Path", () => {
     })
   })
 
-  describe("@@iterator", () => {
-    it("implements the iterator protocol", () => {
-      const nodes = []
-      const path = new Path("users", "0", "name")
-
-      for (const node of path) {
-        nodes.push(node)
-      }
-
-      expect(nodes).to.deep.equal(["users", "0", "name"])
-    })
-
-    it("desctructs path into nodes", () => {
-      const [head, ...tail] = new Path("users", "0", "name")
-      expect(head).to.equal("users")
-      expect(tail).to.deep.equal(["0", "name"])
-    })
-  })
-
   describe("#subpath", () => {
     it("retrieves subpaths from a given path", () => {
       const path = new Path("users", 0, "name")


### PR DESCRIPTION
Babel transform-runtime plugin was also removed, reducing quite considerably the final package size:

Before:

```
Time: 2309ms
      Asset        Size
      index.js     39.4 kB
      index.js.gz  11.8 kB
```

After:

```
Time: 1086ms
      Asset        Size
      index.js     16.4 kB
      index.js.gz  3.31 kB
```

Resolves #46 